### PR TITLE
Custom civilization and leader traits

### DIFF
--- a/Gathering Storm Demo Mod/Gathering Storm Demo Mod/Demo_Text.xml
+++ b/Gathering Storm Demo Mod/Gathering Storm Demo Mod/Demo_Text.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <GameData>
 	<LocalizedText>
+		<!-- DEMO HOUSE BUILDING TEXT -->
 		<Row>
 			<Tag>LOC_BUILDING_DEMO_HOUSE_SAM_NAME</Tag>
 			<Language>en_US</Language>
@@ -11,6 +12,7 @@
 			<Language>en_US</Language>
 			<Text>A demo house which makes life easier.</Text>
 		</Row>
+		<!-- CARTOGRAPHER UNIT TEXT -->
 		<Row>
 			<Tag>LOC_UNIT_CARTOGRAPHER_SAM_NAME</Tag>
 			<Language>en_US</Language>
@@ -20,6 +22,17 @@
 			<Tag>LOC_UNIT_CARTOGRAPHER_SAM_DESCRIPTION</Tag>
 			<Language>en_US</Language>
 			<Text>The Cartographer is great for surveying the land around the map. He is fast and can see far, but is very weak in combat and exerts no zone of control.</Text>
+		</Row>
+		<!-- CARTOGRAPHER UNIT TEXT -->
+		<Row>
+			<Tag>LOC_POLICY_MONUMENTALITY_SAM_DESCRIPTION</Tag>
+			<Language>en_US</Language>
+			<Text>Gain +1 Loyalty per turn in each city in your empire.</Text>
+		</Row>
+		<Row>
+			<Tag>LOC_POLICY_MONUMENTALITY_SAM_NAME</Tag>
+			<Language>en_US</Language>
+			<Text>Monumentality</Text>
 		</Row>
 	</LocalizedText>
 </GameData>

--- a/Gathering Storm Demo Mod/Gathering Storm Demo Mod/Gathering Storm Demo Mod.civ6proj
+++ b/Gathering Storm Demo Mod/Gathering Storm Demo Mod/Gathering Storm Demo Mod.civ6proj
@@ -21,7 +21,7 @@
 </Associations>]]></AssociationData>
     <AssemblyName>Gathering Storm Demo Mod</AssemblyName>
     <RootNamespace>Gathering Storm Demo Mod</RootNamespace>
-    <InGameActionData><![CDATA[<InGameActions><UpdateDatabase id="AddBuilding"><File>Demo_Building.xml</File></UpdateDatabase><UpdateText id="AddText"><File>Demo_Text.xml</File></UpdateText><UpdateIcons id="AddIcons"><File>Demo_Icons.xml</File></UpdateIcons><UpdateDatabase id="AddUnit"><File>Cartographer_Unit.xml</File></UpdateDatabase><UpdateDatabase id="AddCivilization"><File>InGame/Demo_Civilization.xml</File><File>InGame/Demo_Traits.xml</File><File>InGame/Demo_Leader.xml</File></UpdateDatabase><UpdateText id="AddCivilizationText"><File>FrontEnd/Demo_Leader_Config_Text.xml</File><File>InGame/Demo_Civilization_InGame_Text.xml</File></UpdateText></InGameActions>]]></InGameActionData>
+    <InGameActionData><![CDATA[<InGameActions><UpdateDatabase id="AddBuilding"><File>Demo_Building.xml</File></UpdateDatabase><UpdateText id="AddText"><File>Demo_Text.xml</File></UpdateText><UpdateIcons id="AddIcons"><File>Demo_Icons.xml</File></UpdateIcons><UpdateDatabase id="AddUnit"><File>Cartographer_Unit.xml</File></UpdateDatabase><UpdateDatabase id="AddCivilization"><File>InGame/Demo_Civilization.xml</File><File>InGame/Demo_Traits.xml</File><File>InGame/Demo_Leader.xml</File></UpdateDatabase><UpdateText id="AddCivilizationText"><File>FrontEnd/Demo_Leader_Config_Text.xml</File><File>InGame/Demo_Civilization_InGame_Text.xml</File></UpdateText><UpdateDatabase id="AddPolicy"><File>Loyalty_Policy.xml</File></UpdateDatabase></InGameActions>]]></InGameActionData>
     <FrontEndActionData><![CDATA[<FrontEndActions><UpdateDatabase id="DemoLeaderConfig"><File>FrontEnd/Demo_Leader_Config.xml</File></UpdateDatabase><UpdateText id="DemoLeaderTextConfig"><File>FrontEnd/Demo_Leader_Config_Text.xml</File></UpdateText><UpdateIcons id="DemoLeaderIconConfig"><File>FrontEnd/Demo_Leader_Config_Icons.xml</File></UpdateIcons></FrontEndActions>]]></FrontEndActionData>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Default' ">
@@ -62,6 +62,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="InGame\Demo_Traits.xml">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Loyalty_Policy.xml">
       <SubType>Content</SubType>
     </Content>
   </ItemGroup>

--- a/Gathering Storm Demo Mod/Gathering Storm Demo Mod/InGame/Demo_Traits.xml
+++ b/Gathering Storm Demo Mod/Gathering Storm Demo Mod/InGame/Demo_Traits.xml
@@ -48,4 +48,37 @@
 			<Value>SLOT_DIPLOMATIC</Value>
 		</Row>
 	</ModifierArguments>
+	
+	<!-- CIVILIZATION TRAIT -->
+	<TraitModifiers>
+		<Row>
+			<TraitType>TRAIT_CIVILIZATION_DEMO_SAM</TraitType>
+			<ModifierId>TRAIT_DEMO_CIVILIZATION_SAM_MONUMENT_YEILD</ModifierId>
+		</Row>
+	</TraitModifiers>
+
+	<Modifiers>
+		<Row>
+			<ModifierId>TRAIT_DEMO_CIVILIZATION_SAM_MONUMENT_YEILD</ModifierId>
+			<ModifierType>MODIFIER_PLAYER_CITIES_ADJUST_BUILDING_YIELD_CHANGE</ModifierType>
+		</Row>
+	</Modifiers>
+
+	<ModifierArguments>
+		<Row>
+			<ModifierId>TRAIT_DEMO_CIVILIZATION_SAM_MONUMENT_YEILD</ModifierId>
+			<Name>BuildingType</Name>
+			<Value>BUILDING_MONUMENT</Value>
+		</Row>
+		<Row>
+			<ModifierId>TRAIT_DEMO_CIVILIZATION_SAM_MONUMENT_YEILD</ModifierId>
+			<Name>YieldType</Name>
+			<Value>YIELD_PRODUCTION</Value>
+		</Row>
+		<Row>
+			<ModifierId>TRAIT_DEMO_CIVILIZATION_SAM_MONUMENT_YEILD</ModifierId>
+			<Name>Amount</Name>
+			<Value>1</Value>
+		</Row>
+	</ModifierArguments>
 </GameData>

--- a/Gathering Storm Demo Mod/Gathering Storm Demo Mod/InGame/Demo_Traits.xml
+++ b/Gathering Storm Demo Mod/Gathering Storm Demo Mod/InGame/Demo_Traits.xml
@@ -25,4 +25,27 @@
 			<Description>LOC_TRAIT_LEADER_DEMO_LEADER_SAM_DESCRIPTION</Description>
 		</Row>
 	</Traits>
+
+	<!-- LEADER TRAIT MODIFIER -->
+	<TraitModifiers>
+		<Row>
+			<TraitType>TRAIT_LEADER_DEMO_SAM</TraitType>
+			<ModifierId>TRAIT_DEMO_LEADER_SAM_DIPLOMATIC_GOVERNMENT_SLOT</ModifierId>
+		</Row>
+	</TraitModifiers>
+
+	<Modifiers>
+		<Row>
+			<ModifierId>TRAIT_DEMO_LEADER_SAM_DIPLOMATIC_GOVERNMENT_SLOT</ModifierId>
+			<ModifierType>MODIFIER_PLAYER_CULTURE_ADJUST_GOVERNMENT_SLOTS_MODIFIER</ModifierType>
+		</Row>
+	</Modifiers>
+
+	<ModifierArguments>
+		<Row>
+			<ModifierId>TRAIT_DEMO_LEADER_SAM_DIPLOMATIC_GOVERNMENT_SLOT</ModifierId>
+			<Name>GovernmentSlotType</Name>
+			<Value>SLOT_DIPLOMATIC</Value>
+		</Row>
+	</ModifierArguments>
 </GameData>

--- a/Gathering Storm Demo Mod/Gathering Storm Demo Mod/Loyalty_Policy.xml
+++ b/Gathering Storm Demo Mod/Gathering Storm Demo Mod/Loyalty_Policy.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<GameData>
+	<Types>
+		<Row>
+			<Type>POLICY_MONUMENTALITY_SAM</Type>
+			<Kind>KIND_POLICY</Kind>
+		</Row>
+	</Types>
+
+	<Policies>
+		<Row>
+			<PolicyType>POLICY_MONUMENTALITY_SAM</PolicyType>
+			<Description>LOC_POLICY_MONUMENTALITY_SAM_DESCRIPTION</Description>
+			<PrereqCivic>CIVIC_CODE_OF_LAWS</PrereqCivic>
+			<Name>LOC_POLICY_MONUMENTALITY_SAM_NAME</Name>
+			<GovernmentSlotType>SLOT_DIPLOMATIC</GovernmentSlotType>
+		</Row>
+	</Policies>
+
+	<PolicyModifiers>
+		<Row>
+			<PolicyType>POLICY_MONUMENTALITY_SAM</PolicyType>
+			<ModifierId>MONUMENTALITY_SAM_LOYALTY</ModifierId>
+		</Row>
+	</PolicyModifiers>
+
+	<Modifiers>
+		<Row>
+			<ModifierId>MONUMENTALITY_SAM_LOYALTY</ModifierId>
+			<ModifierType>MODIFIER_PLAYER_CITIES_ADJUST_IDENTITY_PER_TURN</ModifierType>
+		</Row>
+	</Modifiers>
+
+	<ModifierArguments>
+		<Row>
+			<ModifierId>MONUMENTALITY_SAM_LOYALTY</ModifierId>
+			<Name>Amount</Name>
+			<Value>1</Value>
+		</Row>
+	</ModifierArguments>
+</GameData>


### PR DESCRIPTION
Implemented the civilization and leader traits of the demo civilization and demo leader, respectively, using modifiers. Additionally, I added an example diplomatic policy to the Code of Laws civic for demonstration purposes and to allow the demo civilization to assign government policies, as they require a diplomatic policy slot.